### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/js/page.js
+++ b/js/page.js
@@ -1,7 +1,12 @@
 $('#small-nav-dropdown').change(function() {
-  window.location = $(this)
+  var selectedValue = $(this)
     .find('option:selected')
-    .val()
+    .val();
+  if (/^https?:\/\/[^\s/$.?#].[^\s]*$/.test(selectedValue)) {
+    window.location = selectedValue;
+  } else {
+    console.error('Invalid URL:', selectedValue);
+  }
 })
 
 const site_tag = 'UA-62780441-30';


### PR DESCRIPTION
Fixes [https://github.com/krishnprakash/devcontainers.github.io/security/code-scanning/1](https://github.com/krishnprakash/devcontainers.github.io/security/code-scanning/1)

To fix the problem, we need to ensure that the value retrieved from the dropdown is properly sanitized before being used. One way to do this is to validate that the value is a safe URL. We can use a regular expression to check that the value is a valid URL before assigning it to `window.location`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
